### PR TITLE
Fix log_space_fft_filtering returning its input with default parameters

### DIFF
--- a/code/aind_smartspim_destripe/filtering.py
+++ b/code/aind_smartspim_destripe/filtering.py
@@ -139,7 +139,7 @@ def gaussian_filter(shape, sigma):
 def log_space_fft_filtering(
     input_image: np.array,
     wavelet: Optional[str] = "db3",
-    level: Optional[int] = 0,
+    level: Optional[int] = None,
     sigma: Optional[int] = 64,
     max_threshold: Optional[int] = 4,
 ):
@@ -173,6 +173,13 @@ def log_space_fft_filtering(
         streaks.
     """
     input_image_log = np.log(1.0 + input_image)
+    # pywt reads level=0 as "no decomposition at all". There are no detail bands, the loop below
+    # never runs, and this function returns its input unchanged, silently and in no time. pystripe,
+    # which this filter follows, guards the same case (`if level == 0: wavedec(img_log, wavelet)`)
+    # and means by it "use the maximum useful level". Keep that meaning, so a caller passing 0 gets
+    # a filter rather than an identity.
+    if not level:
+        level = None
     coeffs = pywt.wavedec2(input_image_log, wavelet=wavelet, level=level)
     approx = coeffs[0]
     detail = coeffs[1:]

--- a/code/tests/test_filtering.py
+++ b/code/tests/test_filtering.py
@@ -168,6 +168,35 @@ class SmartspimFiltering(unittest.TestCase):
         self.assertEqual(result.shape, input_image.shape)
         self.assertTrue(np.all(result > 0))  # Ensure no negative values in the result
 
+    def test_log_space_fft_filtering_removes_stripes_with_defaults(self):
+        """
+        The default parameters must actually filter.
+
+        Guards the case where `level` reaches pywt as 0, which it reads as "no decomposition". The
+        detail bands come back empty, the filtering loop never runs, and the function returns its
+        input. That failure is silent, since the output has the right shape, the right sign and the
+        right dtype, which is all the tests above check. So it is asserted here on the one property
+        that tells a filter apart from an identity.
+        """
+        rows, cols = 128, 128
+        rng = np.random.default_rng(0)
+        background = np.tile(np.linspace(50, 200, cols), (rows, 1))
+        # Horizontal streaks: constant along the columns, varying row to row.
+        streaks = np.tile(rng.normal(0, 15, rows)[:, None], (1, cols))
+        striped = (background + streaks).astype(np.float32)
+
+        filtered = filtering.log_space_fft_filtering(striped)
+
+        def streak_power(image):
+            """Variance of the row means: what a horizontal streak puts there, and little else."""
+            return float(np.var(image.mean(axis=1)))
+
+        self.assertLess(
+            streak_power(filtered),
+            0.5 * streak_power(striped),
+            "the default parameters left the streaks untouched",
+        )
+
     def test_log_space_fft_filtering_small_image(self):
         """
         Testing filtering with a very small image


### PR DESCRIPTION
`log_space_fft_filtering` returns its input unchanged when you call it with its default parameters.

`level` defaults to 0, and pywt reads 0 as "no decomposition". `wavedec2` returns only the approximation, the loop over the detail bands never runs, and the function gives back what it was given. It looks like it worked: right shape, right dtype, no negative values, and it finishes instantly. Three of my runs came back with 0.03% change before I looked at the timing and realised nothing was happening.

`run_capsule.py` passes `level: None` for both of its configs, so the capsule itself has always been fine. Only direct callers of the module are affected.

pystripe, which this filter follows closely, guards the same case:

```python
if level == 0:
    coeffs = wavedec(img_log, wavelet)
else:
    coeffs = wavedec(img_log, wavelet, level)
```

and means by it "use the maximum useful level". This keeps that meaning, so passing 0 explicitly still gives you a filter rather than an identity.

The test asserts the one property that separates a filter from an identity, that the streak power actually drops. The two existing tests check shape, sign and dtype, all of which an identity satisfies, which is why this went unnoticed. Full suite passes with the fix (16 tests), and the new test fails without it.

### A separate question, not changed here

The forward transform is `np.log(1.0 + input_image)` and the inverse is written `np.exp(y) + 1.0`, where the algebraic inverse would be `np.exp(y) - 1.0`. As written every voxel comes back shifted by +2:

```python
>>> flat = np.full((128, 128), 1000.0, dtype=np.float32)
>>> log_space_fft_filtering(flat).mean()
1001.9988
```

I had this as a second commit and then dropped it, because on our data the `- 1.0` version sends about 0.17% of voxels slightly negative (down to -0.5, all of them background at zero), and `test_log_space_fft_filtering` asserts `np.all(result > 0)`. So the `+ 1.0` may well be a deliberate positivity floor rather than a typo. Happy to send it as its own PR, with a clip at zero if you would rather keep the guarantee, but that is your call to make and not mine to guess.

For what it is worth, once it runs the filter is very good.  Thanks for making it available.
